### PR TITLE
Improved weight initialization

### DIFF
--- a/network.py
+++ b/network.py
@@ -4,8 +4,7 @@ from ActivationFunctions import ActivationFunctions
 from CostFunctions import CostFunctions
 import logging
 
-#TODO(1) level 1 : instead of a single function, we can use a list of function pointers (one function for each layer)
-#TODO 1 change the feedforward function to use the list of activation functions and so on
+
 class Network:
     def __init__(self, sizes , activations_functions_names=None, cost_function_name ='quadratic', output_activation_name='softmax'
                  , train_learning_rate=0.1, train_mini_batch_size=10, train_epochs=100):
@@ -76,7 +75,6 @@ class Network:
         current_layer_vector = input_vector.reshape(-1, 1)
         #feedforward the input a through the network
         for bias, weight in zip(self.__biases, self.__weights):
-            #TODO(1)
             z = np.dot(weight, current_layer_vector) + bias
             current_layer_vector = self.__activation_func_list[i](z)
             i += 1

--- a/network.py
+++ b/network.py
@@ -12,8 +12,8 @@ class Network:
         #number of neurons in each layer
         self.__sizes = sizes
         #initialize weights and biases for each layer
-        self.__biases = [np.random.randn(y, 1) for y in sizes[1:]]
-        self.__weights = [np.random.randn(y, x) for x, y in zip(sizes[:-1], sizes[1:])]
+        self.__biases = [np.random.randn(y, 1)  for y in sizes[1:]]
+        self.__weights = [np.random.randn(y, x) * np.sqrt(1./x) for x, y in zip(sizes[:-1], sizes[1:])]
         #stores a activation function name for each layer
         #activation function and its derivative for all layers exept output layer (for now)
         #TODO(1)

--- a/test.py
+++ b/test.py
@@ -31,11 +31,8 @@ def create_and_train_network(train_X_y, test_X_y):
     network_sizes = [784, 128, 64, 10]  # configuration
     activations = ['relu', 'relu', 'softmax']
 
-    test_vec = np.array([1,2,3,-1,21,-20])
-    res = ActivationFunctions.relu(test_vec)
-
     network = Network(sizes=network_sizes, activations_functions_names=activations, output_activation_name='softmax'
-                      , train_learning_rate=0.25, train_mini_batch_size=10, train_epochs=10)
+                      , train_learning_rate=0.01, train_mini_batch_size=10, train_epochs=10)
 
     # Training the network
     network.fit(X_train, y_train, X_test, y_test)


### PR DESCRIPTION
1) **Weight initialization changes**:
Adjusted the weight initialization strategy from a standard normal distribution N(0,1) to a scaled normal distribution N(0,1/(number of inputs to the layer)). This approach is inspired by the He initialization technique outlined in the [book](https://static.latexstudio.net/article/2018/0912/neuralnetworksanddeeplearning.pdf), which is especially beneficial for layers using ReLU activation functions.

Impact:
- Improved Network Learning Rate
- Helped with debugging


2) **Relu issue**
We encountered a critical issue where ReLU activation functions returned the same output for varying inputs, a phenomenon commonly referred to as the "dying ReLU problem."
For a more comprehensive explanation, consider this insightful [article](https://www.linkedin.com/pulse/dying-relu-problem-keep-your-neural-network-alive-snigdha-kakkar/).
The combination of an overly high learning rate (previously set at 0.25) and suboptimal weight initialization contributed to this problem. Adjustments in both areas have transformed our network from producing constant function outputs to demonstrating more of an expected behavior.
The results and comparative tests demonstrating these effects can be reviewed [here](https://github.com/user-attachments/files/15959588/Test_1.txt)


3) **Sigmoid vs. ReLU Comparison**
Conducted a [small experiment](https://github.com/user-attachments/files/15959612/Sigmoid.vs.Relu.txt) to compare the performance and characteristics of Sigmoid and ReLU activation functions within our network context



